### PR TITLE
php8 konformes RFC basiertes stable sort result

### DIFF
--- a/src/RouteTree/RouteTree.php
+++ b/src/RouteTree/RouteTree.php
@@ -489,9 +489,9 @@ class RouteTree
     {
         $this->registeredRoutes = $this->registeredRoutes->sort(function (RegisteredRoute $routeA, RegisteredRoute $routeB) {
             if ($routeA->path === $routeB->path) {
-                return $routeA->routeName > $routeB->routeName;
+                return $routeA->routeName <=> $routeB->routeName;
             }
-            return $routeA->path > $routeB->path;
+            return $routeA->path <=> $routeB->path;
         });
     }
 


### PR DESCRIPTION
php8 erfordert als RFC basiertes stable sort result einen int value <>0 hab > dementsprechend mit dem spaceship operator ausgetauscht