### PR TITLE
Laravel Support > v7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "laravel/framework": ">=5.5 <7.0.0"
+        "laravel/framework": ">=5.5"
     },
     "require-dev": {
         "orchestra/testbench": ">=3.5"

--- a/src/RouteTree/RouteTree.php
+++ b/src/RouteTree/RouteTree.php
@@ -444,6 +444,8 @@ class RouteTree
             if ($currentRoute->getActionMethod() === '\Illuminate\Routing\ViewController') {
                 unset($currentRouteParameters['view']);
                 unset($currentRouteParameters['data']);
+                unset($currentRouteParameters['status']);
+                unset($currentRouteParameters['headers']);
             }
             $parameters = $currentRouteParameters;
         }


### PR DESCRIPTION
I had to update the version requirement for laravel/framework in composer.json in order to install routetree for laravel > v7.
- <i>"laravel/framework": ">=5.5 <7.0.0"</i> => <b>"laravel/framework": ">=5.5"</b>

Further, I updated the function "establishRouteParameters" in RouteTree.php for view actions.
The route parameters "status" and "headers" have not yet been removed which led to an error during render on laravel version >= 8.

These changes have been tested for laravel 8 und 9. Please consider merging them.
