### PR TITLE
Generate sitemap broken

### DIFF
--- a/src/resources/views/sitemap.blade.php
+++ b/src/resources/views/sitemap.blade.php
@@ -1,4 +1,4 @@
-<xml version="1.0" encoding="UTF-8">
+<?php echo '<?xml version="1.0" encoding="utf-8"?>'; ?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
         xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

--- a/src/resources/views/sitemap.blade.php
+++ b/src/resources/views/sitemap.blade.php
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<xml version="1.0" encoding="UTF-8">
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
         xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
@@ -10,3 +10,4 @@
     </url>
     @endforeach
 </urlset>
+</xml>


### PR DESCRIPTION
Hi! :)

the generate-sitemap command uses the src/resources/views/sitemap.blade.php to render the sitemap. This worked until now. I don't know exactly what changed but most likely it has to do with php short opening tags. Either way, this pull request echos the xml opening tag to fix the following error:

> In 6bc41d409dd2b8cc9f5464442b3325201c4d6553.php line 1: syntax error, unexpected identifier "version" (View: /apps/rcode0-public/shared/vendor/webflorist/routetree/src/resources/views/sitemap.blade.php)